### PR TITLE
very minor change in internals

### DIFF
--- a/getcartr/R/dotted.R
+++ b/getcartr/R/dotted.R
@@ -193,7 +193,7 @@ library(Rcartogram)
   warpverb <- function(xy,wg) {
     cents = attr(wg,"cents")
     sizes = attr(wg,"sizes")
-    xyt = (xy-cents[col(xy)]) %*% diag(1/sizes)
+    xyt = t((t(xy)-cents)/sizes)
     xyt <- .decimate(xyt,prec)
     .interpolate(xyt,wg)}
   .apply.polys(spdf,warpverb,wg) }

--- a/getcartr/R/dotted.R
+++ b/getcartr/R/dotted.R
@@ -193,7 +193,7 @@ library(Rcartogram)
   warpverb <- function(xy,wg) {
     cents = attr(wg,"cents")
     sizes = attr(wg,"sizes")
-    xyt = t((t(xy)-cents)/sizes)
+    xyt = (xy-cents[col(xy)]) %*% diag(1/sizes)
     xyt <- .decimate(xyt,prec)
     .interpolate(xyt,wg)}
   .apply.polys(spdf,warpverb,wg) }
@@ -265,7 +265,7 @@ library(Rcartogram)
   nr <- nrow(x)
   result <- .decimate.core(x[1:2,],pr)
   if (nr>2)
-    for (i in 3:nrow(x)) result <- rbind(result,.decimate.core(x[c(i-1,i),],pr)[-1,])
+    for (i in 3:nr) result <- rbind(result,.decimate.core(x[c(i-1,i),],pr)[-1,])
   return(result)
 }
 


### PR DESCRIPTION
noticed you declared `nr` but then didn't use it.

also, another suggestion (not included here):

instead of the iterative version of `.decimate.core` used here, why not just sequence along the edge? this approach is faster in my benchmarks for small levels of precision (it's more or less stable w.r.t. precision, whereas `.decimate.core` had marked increases in computation time for precision <.1. further, it is very consistent in speed across precision levels.

it _is_ slower than the `.decimate.core` version for moderately large levels of precision (relative to the initial distance), which is why I wanted to ping you before including it.

here's what I came up with this morning:

```
.decimate.core<-function(x,pr) {
  if (.lengths(x)<pr)x
  else{
    nn<-ceiling(.lengths(x)/pr)
    cbind(seq(x[1,1],x[2,1],by=(x[2,1]-x[1,1])/nn),
          seq(x[1,2],x[2,2],by=(x[2,2]-x[1,2])/nn))
  }
}
```

this may be able to be sped up. the idea is to divide the line between the pair of points into just enough equal-length segments to make the proximal distances below `pr`.

let me know what you think
